### PR TITLE
Rustfmt, use c_void instead of `()` and start reusing uefi-raw types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crc = "3.0.1"
 linked_list_allocator = "0.10.5"
 log = "0.4.14"
 once_cell = { version = "1.18.0", default-features = false }
+uefi-raw = "0.11.0"
 widestring = { version = "1.0.2", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/src/blockio.rs
+++ b/src/blockio.rs
@@ -13,12 +13,7 @@ use core::ffi::c_void;
 
 const EFI_BLOCK_IO_PROTOCOL_REVISION: u64 = 0x00010000;
 
-const EFI_BLOCK_IO_PROTOCOL_GUID: Guid = guid!(
-    0x964e5b21,
-    0x6459,
-    0x11d2,
-    [0x8e, 0x39, 0x0, 0xa0, 0xc9, 0x69, 0x72, 0x3b]
-);
+const EFI_BLOCK_IO_PROTOCOL_GUID: Guid = guid!("964e5b21-6459-11d2-8e39-00a0c969723b");
 
 /// EFI_BLOCK_IO_MEDIA - refer to the UEFI specification for the meaning of individual fields.
 #[repr(C)]

--- a/src/blockio.rs
+++ b/src/blockio.rs
@@ -9,6 +9,7 @@ use crate::Lba;
 use crate::{guid, Bool, Guid};
 
 use alloc::boxed::Box;
+use core::ffi::c_void;
 
 const EFI_BLOCK_IO_PROTOCOL_REVISION: u64 = 0x00010000;
 
@@ -55,7 +56,7 @@ type ReadWriteBlocks = extern "efiapi" fn(
     media_id: u32,
     lba: Lba,
     buffer_size: usize,
-    buffer: *mut (),
+    buffer: *mut c_void,
 ) -> Status;
 
 type FlushBlocks = extern "efiapi" fn(this: *mut EfiBlockIoProtocol) -> Status;
@@ -111,7 +112,7 @@ extern "efiapi" fn read_blocks(
     media_id: u32,
     lba: Lba,
     buffer_size: usize,
-    buffer: *mut (),
+    buffer: *mut c_void,
 ) -> Status {
     log::trace!("Calling read_blocks");
     let this = unsafe { &mut *this };
@@ -144,7 +145,7 @@ extern "efiapi" fn write_blocks(
     _media_id: u32,
     _lba: Lba,
     _buffer_size: usize,
-    _buffer: *mut (),
+    _buffer: *mut c_void,
 ) -> Status {
     Status::EFI_WRITE_PROTECTED
 }

--- a/src/bootservices.rs
+++ b/src/bootservices.rs
@@ -570,10 +570,7 @@ extern "efiapi" fn register_protocol_notify(
     Status::EFI_OUT_OF_RESOURCES
 }
 
-fn get_handle_vec(
-    search_type: &LocateSearchType,
-    protocol: *const Guid,
-) -> Vec<Handle> {
+fn get_handle_vec(search_type: &LocateSearchType, protocol: *const Guid) -> Vec<Handle> {
     let protocol = if !protocol.is_null() {
         Some(unsafe { &*protocol })
     } else {

--- a/src/configtable.rs
+++ b/src/configtable.rs
@@ -11,16 +11,17 @@ use crate::EFI;
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::cell::RefCell;
+use core::ffi::c_void;
 use core::ptr::NonNull;
 use core::slice;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub(crate) struct Tuple(Guid, *const ());
+pub(crate) struct Tuple(Guid, *const c_void);
 
 pub enum ConfigurationTablePointer {
     Managed(NonNull<u8>),
-    Raw(*const ()),
+    Raw(*const c_void),
 }
 
 pub(crate) struct ConfigurationTable {
@@ -31,15 +32,15 @@ pub(crate) struct ConfigurationTable {
 impl ConfigurationTable {
     fn as_tuple(&self) -> Tuple {
         let p = match self.p {
-            Managed(p) => p.as_ptr() as *const (),
+            Managed(p) => p.as_ptr().cast(),
             Raw(p) => p,
         };
         Tuple(self.guid, p)
     }
 }
 
-impl From<*const ()> for ConfigurationTablePointer {
-    fn from(p: *const ()) -> Self {
+impl From<*const c_void> for ConfigurationTablePointer {
+    fn from(p: *const c_void) -> Self {
         Raw(p)
     }
 }

--- a/src/configtable.rs
+++ b/src/configtable.rs
@@ -4,8 +4,8 @@
 
 use crate::ConfigurationTablePointer::*;
 use crate::EfiContext;
-use crate::Guid;
 use crate::EfiMemoryType::EfiRuntimeServicesData;
+use crate::Guid;
 use crate::PoolBox;
 use crate::EFI;
 use alloc::collections::BTreeMap;

--- a/src/devicepath.rs
+++ b/src/devicepath.rs
@@ -4,12 +4,7 @@
 
 use crate::{guid, Guid};
 
-pub const EFI_DEVICE_PATH_PROTOCOL_GUID: Guid = guid!(
-    0x9576e91,
-    0x6d3f,
-    0x11d2,
-    [0x8e, 0x39, 0x0, 0xa0, 0xc9, 0x69, 0x72, 0x3b]
-);
+pub const EFI_DEVICE_PATH_PROTOCOL_GUID: Guid = guid!("09576e91-6d3f-11d2-8e39-00a0c969723b");
 
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, PartialEq, Debug)]

--- a/src/initrdloadfile2.rs
+++ b/src/initrdloadfile2.rs
@@ -12,7 +12,7 @@ use crate::{guid, Guid};
 use crate::{status::*, Bool};
 
 use alloc::boxed::Box;
-use core::mem::*;
+use core::{ffi::c_void, mem::*};
 
 pub const EFI_LOAD_FILE2_PROTOCOL_GUID: Guid = guid!(
     0x4006c0c1,
@@ -21,8 +21,13 @@ pub const EFI_LOAD_FILE2_PROTOCOL_GUID: Guid = guid!(
     [0x99, 0x6d, 0x4a, 0x6c, 0x87, 0x24, 0xe0, 0x6d]
 );
 
-type LoadFile =
-    extern "efiapi" fn(*mut EfiLoadFile2, *const DevicePath, Bool, *mut usize, *mut ()) -> Status;
+type LoadFile = extern "efiapi" fn(
+    *mut EfiLoadFile2,
+    *const DevicePath,
+    Bool,
+    *mut usize,
+    *mut c_void,
+) -> Status;
 
 #[repr(C)]
 pub struct EfiLoadFile2 {
@@ -60,7 +65,7 @@ extern "efiapi" fn load_file(
     file_path: *const DevicePath,
     boot_policy: Bool,
     buffer_size: *mut usize,
-    buffer: *mut (),
+    buffer: *mut c_void,
 ) -> Status {
     if boot_policy != 0 {
         return Status::EFI_UNSUPPORTED;

--- a/src/initrdloadfile2.rs
+++ b/src/initrdloadfile2.rs
@@ -14,12 +14,7 @@ use crate::{status::*, Bool};
 use alloc::boxed::Box;
 use core::{ffi::c_void, mem::*};
 
-pub const EFI_LOAD_FILE2_PROTOCOL_GUID: Guid = guid!(
-    0x4006c0c1,
-    0xfcb3,
-    0x403e,
-    [0x99, 0x6d, 0x4a, 0x6c, 0x87, 0x24, 0xe0, 0x6d]
-);
+pub const EFI_LOAD_FILE2_PROTOCOL_GUID: Guid = guid!("4006c0c1-fcb3-403e-996d-4a6c8724e06d");
 
 type LoadFile = extern "efiapi" fn(
     *mut EfiLoadFile2,
@@ -53,12 +48,7 @@ impl EfiProtocol for InitrdDevicePath {
     }
 }
 
-const LINUX_EFI_INITRD_MEDIA_GUID: Guid = guid!(
-    0x5568e427,
-    0x68fc,
-    0x4f3d,
-    [0xac, 0x74, 0xca, 0x55, 0x52, 0x31, 0xcc, 0x68]
-);
+const LINUX_EFI_INITRD_MEDIA_GUID: Guid = guid!("5568e427-68fc-4f3d-ac74-ca555231cc68");
 
 extern "efiapi" fn load_file(
     this: *mut EfiLoadFile2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,26 +121,7 @@ const TPL_NOTIFY: Tpl = 16;
 #[allow(dead_code)]
 const TPL_HIGH_LEVEL: Tpl = 31;
 
-#[derive(PartialEq, PartialOrd, Eq, Ord, Clone, Copy, Debug)]
-#[repr(C)]
-pub struct Guid {
-    pub data1: u32,
-    pub data2: u16,
-    pub data3: u16,
-    pub data4: [u8; 8],
-}
-
-#[macro_export]
-macro_rules! guid {
-    ($a:literal, $b:literal, $c: literal, $d:expr) => {
-        Guid {
-            data1: $a,
-            data2: $b,
-            data3: $c,
-            data4: $d,
-        }
-    };
-}
+pub use uefi_raw::{guid, Guid};
 
 /// An implementation of this trait may be provided to the EFI runtime at initialization
 /// time, allowing it to print diagnostic messages, and check for key presses.
@@ -224,12 +205,7 @@ pub trait Random {
     fn get_entropy(&self, bytes: &mut [u8], use_raw: bool) -> bool;
 }
 
-const EFI_RT_PROPERTIES_TABLE_GUID: Guid = guid!(
-    0xeb66918a,
-    0x7eef,
-    0x402a,
-    [0x84, 0x2e, 0x93, 0x1d, 0x21, 0xc3, 0x8a, 0xe9]
-);
+const EFI_RT_PROPERTIES_TABLE_GUID: Guid = guid!("eb66918a-7eef-402a-842e-931d21c38ae9");
 
 const EFI_RT_SUPPORTED_GET_TIME: u32 = 0x0001;
 const EFI_RT_SUPPORTED_SET_TIME: u32 = 0x0002;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,7 +287,10 @@ impl Deref for EfiContextHolder {
     type Target = EfiContext;
 
     fn deref(&self) -> &Self::Target {
-        &self.0.get().expect("efiloader::init() has not been called yet")
+        &self
+            .0
+            .get()
+            .expect("efiloader::init() has not been called yet")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ use crate::{
 };
 
 use core::cell::*;
+use core::ffi::c_void;
 use core::mem::*;
 use core::ops::*;
 use core::pin::*;
@@ -103,8 +104,8 @@ type VirtualAddress = u64;
 pub type Handle = usize;
 type Tpl = usize;
 #[repr(transparent)]
-pub struct Event(*mut ());
-type EventNotify = extern "efiapi" fn(Event, *const ());
+pub struct Event(*mut c_void);
+type EventNotify = extern "efiapi" fn(Event, *const c_void);
 pub type Lba = u64;
 
 pub(crate) fn new_handle() -> usize {
@@ -195,7 +196,7 @@ pub trait FileLoader {
     /// caller to ensure that `loadbuffer` points to a buffer with sufficient space.
     unsafe fn load_range<'a>(
         &self,
-        loadbuffer: *mut (),
+        loadbuffer: *mut c_void,
         offset: usize,
         size: usize,
     ) -> Result<(), &str>;
@@ -250,8 +251,8 @@ pub trait EfiProtocol {
     /// assumes that the struct is `#[repr(C)]` and exposes the C function pointers directly.
     /// In cases where the `EfiProtocol` implementation wraps a C struct in a different manner,
     /// this method may be overridden to produce the C struct pointer in another way.
-    fn as_proto_ptr(&self) -> *const () {
-        self as *const _ as *const ()
+    fn as_proto_ptr(&self) -> *const c_void {
+        self as *const _ as *const c_void
     }
 
     /// A reference to the `Guid` that identifies the implementation of the EFI protocol.

--- a/src/loadedimage.rs
+++ b/src/loadedimage.rs
@@ -42,11 +42,11 @@ pub struct EfiLoadedImage {
     parent_handle: Handle,
     system_table: *const SystemTable,
     device_handle: Handle,
-    file_path: *const (), //DevicePath,
+    file_path: *const c_void, //DevicePath,
     pub reserved: usize,
     load_options_size: u32,
-    load_options: *const (),
-    image_base: *const (),
+    load_options: *const c_void,
+    image_base: *const c_void,
     image_size: u64,
     image_code_type: EfiMemoryType,
     image_data_type: EfiMemoryType,
@@ -162,7 +162,7 @@ impl LoadedImageData {
 
         let c = &self.load_options;
         let loaded_image = unsafe { &mut *self.loaded_image };
-        loaded_image.load_options = c.as_ptr() as *const ();
+        loaded_image.load_options = c.as_ptr().cast();
         loaded_image.load_options_size = (c.len() * core::mem::size_of::<u16>()) as u32;
     }
 
@@ -176,7 +176,7 @@ extern "C" {
     fn start_image(
         image_handle: Handle,
         system_table: *const SystemTable,
-        entrypoint: *const (),
+        entrypoint: *const c_void,
         sp_buffer: *const usize,
         stack: *mut u8,
     ) -> Status;

--- a/src/loadedimage.rs
+++ b/src/loadedimage.rs
@@ -12,21 +12,12 @@ use crate::{memorytype::*, status::*, systemtable::*, Guid, Handle};
 
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use core::ffi::c_void;
 use core::ptr;
 
-pub const EFI_LOADED_IMAGE_PROTOCOL_GUID: Guid = guid!(
-    0x5B1B31A1,
-    0x9562,
-    0x11d2,
-    [0x8E, 0x3F, 0x00, 0xA0, 0xC9, 0x69, 0x72, 0x3B]
-);
+pub const EFI_LOADED_IMAGE_PROTOCOL_GUID: Guid = guid!("5b1b31a1-9562-11d2-8e3f-00a0c969723b");
 
-pub const LINUX_EFI_LOADED_IMAGE_RAND_GUID: Guid = guid!(
-    0xf5a37b6d,
-    0x3344,
-    0x42a5,
-    [0xb6, 0xbb, 0x97, 0x86, 0x48, 0xc1, 0x89, 0x0a]
-);
+pub const LINUX_EFI_LOADED_IMAGE_RAND_GUID: Guid = guid!("f5a37b6d-3344-42a5-b6bb-978648c1890a");
 
 const EFI_LOADED_IMAGE_PROTOCOL_REVISION: u32 = 0x1000;
 

--- a/src/memattr.rs
+++ b/src/memattr.rs
@@ -5,12 +5,7 @@
 use crate::*;
 use crate::{status::*, Guid};
 
-pub const EFI_MEMORY_ATTRIBUTE_PROTOCOL_GUID: Guid = guid!(
-    0xf4560cf6,
-    0x40ec,
-    0x4b4a,
-    [0xa1, 0x92, 0xbf, 0x1d, 0x57, 0xd0, 0xb1, 0x89]
-);
+pub const EFI_MEMORY_ATTRIBUTE_PROTOCOL_GUID: Guid = guid!("f4560cf6-40ec-4b4a-a192-bf1d57d0b189");
 
 #[repr(C)]
 pub struct EfiMemoryAttribute {

--- a/src/memmap.rs
+++ b/src/memmap.rs
@@ -43,12 +43,7 @@ pub fn size_to_pages(size: usize) -> usize {
 
 const EFI_MEMORY_ATTRIBUTES_FLAGS_RT_FORWARD_CONTROL_FLOW_GUARD: u32 = 0x1;
 
-const EFI_MEMORY_ATTRIBUTES_TABLE_GUID: Guid = guid!(
-    0xdcfa911d,
-    0x26eb,
-    0x469f,
-    [0xa2, 0x20, 0x38, 0xb7, 0xdc, 0x46, 0x12, 0x20]
-);
+const EFI_MEMORY_ATTRIBUTES_TABLE_GUID: Guid = guid!("dcfa911d-26eb-469f-a220-38b7dc461220");
 
 #[derive(Debug)]
 #[repr(C)]

--- a/src/memmap.rs
+++ b/src/memmap.rs
@@ -411,13 +411,7 @@ impl MemoryMap {
 
     pub(crate) fn free_pages(&self, base: u64, pages: usize) -> Result<(), ()> {
         let size = pages << EFI_PAGE_SHIFT;
-        self.convert_region(
-            base,
-            size,
-            None,
-            EfiConventionalMemory,
-            0,
-        )
+        self.convert_region(base, size, None, EfiConventionalMemory, 0)
     }
 
     pub(crate) fn allocate_pages(

--- a/src/peloader.rs
+++ b/src/peloader.rs
@@ -7,7 +7,7 @@ use crate::memorytype::*;
 use crate::EfiContext;
 use crate::MemoryMapper;
 use crate::EFI_PAGE_MASK;
-use crate::{FileLoader, EfiMemoryType, Placement};
+use crate::{EfiMemoryType, FileLoader, Placement};
 
 use alloc::vec::Vec;
 use core::mem::{size_of, MaybeUninit};

--- a/src/poolalloc.rs
+++ b/src/poolalloc.rs
@@ -3,8 +3,8 @@
 // Author: Ard Biesheuvel <ardb@google.com>
 
 use crate::memmap;
-use crate::MemoryMap;
 use crate::EfiMemoryType;
+use crate::MemoryMap;
 use crate::Placement;
 use crate::EFI_MEMORY_XP;
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -9,31 +9,16 @@ use crate::{status::*, Guid};
 
 use core::slice;
 
-pub const EFI_RNG_PROTOCOL_GUID: Guid = guid!(
-    0x3152bca5,
-    0xeade,
-    0x433d,
-    [0x86, 0x2e, 0xc0, 0x1c, 0xdc, 0x29, 0x1f, 0x44]
-);
+pub const EFI_RNG_PROTOCOL_GUID: Guid = guid!("3152bca5-eade-433d-862e-c01cdc291f44");
 
 type EfiRngAlgo = Guid;
 
 // Don't describe the raw algorithm as the default, so that we can serve
 // calls to the default RNG from RNDR as well, without knowing or having
 // to specify what RNDR is backed by
-const RNG_ALGORITHM_DEFAULT: EfiRngAlgo = guid!(
-    0xb65fc704,
-    0x93b4,
-    0x4301,
-    [0x90, 0xea, 0xa7, 0x5c, 0x33, 0x93, 0xb5, 0xe9]
-);
+const RNG_ALGORITHM_DEFAULT: EfiRngAlgo = guid!("b65fc704-93b4-4301-90ea-a75c3393b5e9");
 
-const EFI_RNG_ALGORITHM_RAW: EfiRngAlgo = guid!(
-    0xe43176d7,
-    0xb6e8,
-    0x4827,
-    [0xb7, 0x84, 0x7f, 0xfd, 0xc4, 0xb6, 0x85, 0x61]
-);
+const EFI_RNG_ALGORITHM_RAW: EfiRngAlgo = guid!("e43176d7-b6e8-4827-b784-7ffdc4b68561");
 
 #[derive(Debug)]
 #[repr(C)]

--- a/src/runtimeservices.rs
+++ b/src/runtimeservices.rs
@@ -6,6 +6,8 @@ use crate::UEFI_REVISION;
 use crate::{memorytype::*, status::*, tableheader::*};
 use crate::{Bool, Char16, Guid, PhysicalAddress};
 
+use core::ffi::c_void;
+
 #[derive(Debug)]
 #[repr(C)]
 pub struct Time {
@@ -64,14 +66,14 @@ type SetVirtualAddressMap = extern "efiapi" fn(
 ) -> Status;
 
 type ConvertPointer =
-    extern "efiapi" fn(_debug_disposition: usize, _address: *const *mut ()) -> Status;
+    extern "efiapi" fn(_debug_disposition: usize, _address: *const *mut c_void) -> Status;
 
 pub type GetVariable = extern "efiapi" fn(
     _variable_name: *const Char16,
     _vendor_guid: *const Guid,
     _attributes: *mut u32,
     _data_size: *mut usize,
-    _data: *mut (),
+    _data: *mut c_void,
 ) -> Status;
 
 pub type GetNextVariableName = extern "efiapi" fn(
@@ -85,7 +87,7 @@ pub type SetVariable = extern "efiapi" fn(
     _vendor_guid: *const Guid,
     _attributes: *const u32,
     _data_size: *const usize,
-    _data: *const (),
+    _data: *const c_void,
 ) -> Status;
 
 type GetNextHighMonotonicCount = extern "efiapi" fn(_high_count: *mut u32) -> Status;
@@ -94,7 +96,7 @@ pub type ResetSystem = extern "efiapi" fn(
     _reset_type: ResetType,
     _reset_status: Status,
     _data_size: usize,
-    _reset_data: *const (),
+    _reset_data: *const c_void,
 ) -> Status;
 
 type UpdateCapsule = extern "efiapi" fn(
@@ -170,7 +172,10 @@ extern "efiapi" fn set_virtual_address_map(
     Status::EFI_UNSUPPORTED
 }
 
-extern "efiapi" fn convert_pointer(_debug_disposition: usize, _address: *const *mut ()) -> Status {
+extern "efiapi" fn convert_pointer(
+    _debug_disposition: usize,
+    _address: *const *mut c_void,
+) -> Status {
     Status::EFI_UNSUPPORTED
 }
 
@@ -179,7 +184,7 @@ extern "efiapi" fn get_variable(
     _vendor_guid: *const Guid,
     _attributes: *mut u32,
     _data_size: *mut usize,
-    _data: *mut (),
+    _data: *mut c_void,
 ) -> Status {
     Status::EFI_NOT_FOUND
 }
@@ -197,7 +202,7 @@ extern "efiapi" fn set_variable(
     _vendor_guid: *const Guid,
     _attributes: *const u32,
     _data_size: *const usize,
-    _data: *const (),
+    _data: *const c_void,
 ) -> Status {
     Status::EFI_UNSUPPORTED
 }
@@ -210,7 +215,7 @@ extern "efiapi" fn reset_system(
     _reset_type: ResetType,
     _reset_status: Status,
     _data_size: usize,
-    _reset_data: *const (),
+    _reset_data: *const c_void,
 ) -> Status {
     Status::EFI_UNSUPPORTED
 }

--- a/src/simpletext.rs
+++ b/src/simpletext.rs
@@ -11,19 +11,9 @@ use core::marker::PhantomPinned;
 use core::pin::Pin;
 use core::ptr;
 
-const EFI_SIMPLE_TEXT_INPUT_PROTOCOL_GUID: Guid = guid!(
-    0x387477c1,
-    0x69c7,
-    0x11d2,
-    [0x8e, 0x39, 0x0, 0xa0, 0xc9, 0x69, 0x72, 0x3b]
-);
+const EFI_SIMPLE_TEXT_INPUT_PROTOCOL_GUID: Guid = guid!("387477c1-69c7-11d2-8e39-00a0c969723b");
 
-const EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_GUID: Guid = guid!(
-    0x387477c2,
-    0x69c7,
-    0x11d2,
-    [0x8e, 0x39, 0x0, 0xa0, 0xc9, 0x69, 0x72, 0x3b]
-);
+const EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_GUID: Guid = guid!("387477c2-69c7-11d2-8e39-00a0c969723b");
 
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]


### PR DESCRIPTION
Tested with efilite: https://github.com/epilys/efilite/tree/efiloader-fork

Signed-off-by: Manos Pitsidianakis <manos@pitsidianak.is>